### PR TITLE
Column.metadata field and updated sample_polars interface to match dataframely changes

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.11 (2025-09-11)
+- implemented Column.metadata field
+- updated sample_polars interface to match dataframely changes (num_rows=None by default)
+
 ## 0.2.10 (2025-09-10)
 - implemented Column.name and Column.polars fields/properties (dataframely uses Column.col)
 - implemented nicer __str__ and __repr__ for Column and ColSpec

--- a/src/pydiverse/colspec/columns/_base.py
+++ b/src/pydiverse/colspec/columns/_base.py
@@ -5,6 +5,7 @@ import datetime as dt
 import inspect
 from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import Callable
+from typing import Any
 
 from pydiverse.colspec.optional_dependency import dy
 from pydiverse.common import Dtype
@@ -41,6 +42,7 @@ class Column(ABC, ColExpr, metaclass=ColumnMeta):
         primary_key: bool = False,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -54,11 +56,14 @@ class Column(ABC, ColExpr, metaclass=ColumnMeta):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name. If unset, colspec
                 internally sets the alias to the column's name in the parent schema.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         self.nullable = nullable and not primary_key
         self.primary_key = primary_key
         self.check = check
         self.alias = alias
+        self.metadata = metadata
 
         # cached state:
         self.name = None  # this will be overridden by ColSpec.__getattribute__

--- a/src/pydiverse/colspec/columns/any.py
+++ b/src/pydiverse/colspec/columns/any.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -17,6 +18,7 @@ class Any(Column):
         *,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -26,8 +28,16 @@ class Any(Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
-        super().__init__(nullable=True, primary_key=False, check=check, alias=alias)
+        super().__init__(
+            nullable=True,
+            primary_key=False,
+            check=check,
+            alias=alias,
+            metadata=metadata,
+        )
 
     def dtype(self) -> pdc.Dtype:
         raise NotImplementedError(

--- a/src/pydiverse/colspec/columns/datetime.py
+++ b/src/pydiverse/colspec/columns/datetime.py
@@ -3,6 +3,7 @@
 
 import datetime as dt
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -36,6 +37,7 @@ class Date(OrdinalMixin[dt.date], Column):
         resolution: str | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -70,6 +72,8 @@ class Date(OrdinalMixin[dt.date], Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         # TODO: implement date_matches_resolution
         # if resolution is not None:
@@ -99,6 +103,7 @@ class Date(OrdinalMixin[dt.date], Column):
             max_exclusive=max_exclusive,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
         self.resolution = resolution
 
@@ -129,7 +134,7 @@ class Time(OrdinalMixin[dt.time], Column):
         max_exclusive: dt.time | None = None,
         resolution: str | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
-        alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -163,6 +168,8 @@ class Time(OrdinalMixin[dt.time], Column):
             alias: An overwrite for this column's name which allows for using a column
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
+                happen with metadata. It is just stored.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
                 names, the specified alias is the only valid name.
         """
         # # pydiverse.transform is currently not able to check resolution problems.
@@ -194,7 +201,7 @@ class Time(OrdinalMixin[dt.time], Column):
             max=max,
             max_exclusive=max_exclusive,
             check=check,
-            alias=alias,
+            metadata=metadata,
         )
         self.resolution = resolution
 
@@ -233,6 +240,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
         time_zone: str | dt.tzinfo | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -271,6 +279,8 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         # if resolution is not None and min is not None:
         #     if not datetime_matches_resolution(min, resolution):
@@ -294,6 +304,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
             max_exclusive=max_exclusive,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
         self.resolution = resolution
         self.time_zone = time_zone
@@ -326,6 +337,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
         resolution: str | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -360,6 +372,8 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         # if resolution is not None and min is not None:
         #     if not timedelta_matches_resolution(min, resolution):
@@ -383,6 +397,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
             max_exclusive=max_exclusive,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
         self.resolution = resolution
 

--- a/src/pydiverse/colspec/columns/decimal.py
+++ b/src/pydiverse/colspec/columns/decimal.py
@@ -5,6 +5,7 @@ import copy
 import decimal
 import math
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -29,6 +30,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
         max_exclusive: decimal.Decimal | float | int | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -76,6 +78,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
             max_exclusive=max_exclusive,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
         self.precision = precision
         self.scale = scale

--- a/src/pydiverse/colspec/columns/enum.py
+++ b/src/pydiverse/colspec/columns/enum.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -21,6 +22,7 @@ class Enum(Column):
         primary_key: bool = False,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -34,9 +36,15 @@ class Enum(Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         super().__init__(
-            nullable=nullable, primary_key=primary_key, check=check, alias=alias
+            nullable=nullable,
+            primary_key=primary_key,
+            check=check,
+            alias=alias,
+            metadata=metadata,
         )
         self.categories = categories
 

--- a/src/pydiverse/colspec/columns/float.py
+++ b/src/pydiverse/colspec/columns/float.py
@@ -3,6 +3,7 @@
 import sys
 from abc import abstractmethod
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -24,6 +25,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
         max_exclusive: float | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -42,6 +44,8 @@ class _BaseFloat(OrdinalMixin[float], Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         if min is not None and min < self.min_value:
             raise ValueError("Minimum value is too small for the data type.")
@@ -57,6 +61,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
             max_exclusive=max_exclusive,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
 
     @classproperty

--- a/src/pydiverse/colspec/columns/integer.py
+++ b/src/pydiverse/colspec/columns/integer.py
@@ -3,6 +3,7 @@
 
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -25,6 +26,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
         is_in: Sequence[int] | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -45,6 +47,8 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         if min is not None and min < self.min_value:
             raise ValueError("`min` is too small for the data type.")
@@ -65,6 +69,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
             is_in=is_in,
             check=check,
             alias=alias,
+            metadata=metadata,
         )
 
     @classproperty

--- a/src/pydiverse/colspec/columns/list.py
+++ b/src/pydiverse/colspec/columns/list.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -23,6 +24,7 @@ class List(Column):
         alias: str | None = None,
         min_length: int | None = None,
         max_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -41,7 +43,11 @@ class List(Column):
                 names, the specified alias is the only valid name.
         """
         super().__init__(
-            nullable=nullable, primary_key=primary_key, check=check, alias=alias
+            nullable=nullable,
+            primary_key=primary_key,
+            check=check,
+            alias=alias,
+            metadata=metadata,
         )
         self.inner = inner
         self.min_length = min_length

--- a/src/pydiverse/colspec/columns/string.py
+++ b/src/pydiverse/colspec/columns/string.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -24,6 +25,7 @@ class String(Column):
         regex: str | None = None,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -40,9 +42,15 @@ class String(Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         super().__init__(
-            nullable=nullable, primary_key=primary_key, check=check, alias=alias
+            nullable=nullable,
+            primary_key=primary_key,
+            check=check,
+            alias=alias,
+            metadata=metadata,
         )
         self.min_length = min_length
         self.max_length = max_length

--- a/src/pydiverse/colspec/columns/struct.py
+++ b/src/pydiverse/colspec/columns/struct.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Callable
+from typing import Any
 
 import pydiverse.common as pdc
 
@@ -20,6 +21,7 @@ class Struct(Column):
         primary_key: bool = False,
         check: Callable[[ColExpr], ColExpr] | None = None,
         alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -35,9 +37,15 @@ class Struct(Column):
                 name that is not a valid Python identifier. Especially note that setting
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column. Nothing will
+                happen with metadata. It is just stored.
         """
         super().__init__(
-            nullable=nullable, primary_key=primary_key, check=check, alias=alias
+            nullable=nullable,
+            primary_key=primary_key,
+            check=check,
+            alias=alias,
+            metadata=metadata,
         )
         self.inner = inner
 

--- a/tests/columns/test_metadata.py
+++ b/tests/columns/test_metadata.py
@@ -1,0 +1,36 @@
+# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) QuantCo 2024-2025
+# SPDX-License-Identifier: BSD-3-Clause
+import pytest
+
+import pydiverse.colspec as cs
+from pydiverse.colspec import Column
+from pydiverse.colspec.testing import COLUMN_TYPES, SUPERTYPE_COLUMN_TYPES
+
+
+class SchemaWithMetadata(cs.ColSpec):
+    a = cs.Int64(metadata={"masked": True, "comment": "foo", "order": 1})
+    b = cs.String()
+
+
+def test_metadata() -> None:
+    assert SchemaWithMetadata.a.metadata == {
+        "masked": True,
+        "comment": "foo",
+        "order": 1,
+    }
+    assert SchemaWithMetadata.b.metadata is None
+
+
+@pytest.mark.parametrize("column_type", COLUMN_TYPES + SUPERTYPE_COLUMN_TYPES)
+def test_constructor_metadata(column_type: type[Column]):
+    column = column_type(metadata={"masked": True, "comment": "foo", "order": 1})
+    assert column.metadata == {
+        "masked": True,
+        "comment": "foo",
+        "order": 1,
+    }
+    column2 = column_type()
+    assert column2.metadata is None

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -136,7 +136,9 @@ def test_sample_overrides_with_removing_groups():
     generator = Generator()
     n = 333  # we cannot use something too large here or we'll never return
     overrides = np.random.randint(100, size=n)
-    df = LimitedComplexColSpec.sample_polars(n, generator, overrides={"b": overrides})
+    df = LimitedComplexColSpec.sample_polars(
+        n, generator=generator, overrides={"b": overrides}
+    )
     LimitedComplexColSpec.validate_polars(df)
     tbl = pdt.Table(df)
     LimitedComplexColSpec.validate(tbl)
@@ -173,5 +175,6 @@ def test_sample_overrides_invalid_column():
 
 @pytest.mark.skipif(dy.Column is None, reason="dataframely is required for this test")
 def test_sample_overrides_invalid_length():
+    MySimpleColSpec.sample_polars(overrides={"a": [1, 2]})
     with pytest.raises(ValueError, match=r"`num_rows` is different"):
-        MySimpleColSpec.sample_polars(overrides={"a": [1, 2]})
+        MySimpleColSpec.sample_polars(num_rows=1, overrides={"a": [1, 2]})


### PR DESCRIPTION
- updated sample_polars interface to match dataframely changes (num_rows=None by default)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
